### PR TITLE
Preserve child objects on ingest if collection is preserved

### DIFF
--- a/islandora_westvault.module
+++ b/islandora_westvault.module
@@ -112,3 +112,24 @@ function islandora_westvault_cron() {
   }
   islandora_westvault_owncloud_sync();
 }
+
+/* 
+ * Implements hook_islandora_object_ingested().
+ */
+function islandora_westvault_islandora_object_ingested(AbstractObject $object) {
+  module_load_include('module', 'islandora_basic_collection');
+  $parent_collections = islandora_get_parents_from_rels_ext($object);
+  dd($parent_collections);
+  foreach ($parent_collections AS $parent) {
+    $parent_test = islandora_object_load($parent);
+    $ds = $parent_test["PRESERVATION"];
+    if (!empty($ds)) {
+      $parent_preservation = TRUE;
+    }
+  }
+  if ($parent_preservation == TRUE) {
+    module_load_include('inc', 'islandora_westvault', 'includes/management_form');
+    islandora_westvault_add_preservation_datastream($object);
+  }
+// For later    $xml = simplexml_load_string($ds->content);
+}


### PR DESCRIPTION
This works! Care to test and confirm, @mjordan?

Testing approach:
- Preserve some objects individually; should still work as expected
- Ingest an object into a collection with no PRESERVATION datastream. No PRESERVATION datastream should be added.
- Preserve a collection
- Ingest new object into the preserved collection. This new object should have a PRESERVATION datastream.

I've begun working on the next step, but should get this version merged first.