### PR TITLE
Skip child collections when preservation from parent

### DIFF
--- a/includes/management_form.inc
+++ b/includes/management_form.inc
@@ -50,6 +50,8 @@ function islandora_westvault_form($form, &$form_state, AbstractObject $object) {
         'allchildren' => t('All children of this collection (existing and new)'),
         'currentchildren' => t('Current children only - new objects will not be preserved'),
       ),
+      '#description' => t('How to handle children of this collection. This setting excludes child collections.
+      Child collections must be configured individually.'),
     );
     module_load_include('module', 'islandora_basic_collection');
     $collection_children = islandora_basic_collection_get_member_objects($object);
@@ -76,7 +78,9 @@ function islandora_westvault_form_submit($form, &$form_state) {
         foreach ($collection_children[1] AS $child) {
           // Apply the PRESERVATION datastream!
           $child_object = islandora_object_load($child['object']['value']);
-          islandora_westvault_add_preservation_datastream($child_object);
+          if (!in_array('islandora:collectionCModel', $child_object->models)) {
+            islandora_westvault_add_preservation_datastream($child_object);
+          }
         }
       }
     }


### PR DESCRIPTION
Addresses #23. If a collection is configured to preserve its children, child collections are skipped. User is told in the menu description that child collections must be configured individually.

Future development could allow child collections to inherit the preservationMethod of the parent and run the loop on all their children as well. This is a first step - stops child collections from getting a PRESERVATION datastream without any functionality attached.