### PR TITLE
Paged content

### DIFF
--- a/includes/management_form.inc
+++ b/includes/management_form.inc
@@ -84,6 +84,19 @@ function islandora_westvault_form_submit($form, &$form_state) {
         }
       }
     }
+    elseif (in_array('islandora:newspaperCModel', $object->models)) {
+      // Do newspaper things
+    }
+    elseif (in_array('islandora:bookCModel', $object->models)) {
+      // Add PRESERVATION datastream to all pages.
+      module_load_include('inc', 'islandora_paged_content', 'includes/utilities');
+      $pages = islandora_paged_content_get_pages($object);
+      dd($pages);
+      foreach ($pages AS $page) {
+        $page_object = islandora_object_load($page['pid']);
+        islandora_westvault_add_preservation_datastream($page_object);
+      }
+    }
   }
   else {
     $object->purgeDatastream('PRESERVATION');

--- a/includes/management_form.inc
+++ b/includes/management_form.inc
@@ -86,21 +86,33 @@ function islandora_westvault_form_submit($form, &$form_state) {
     }
     elseif (in_array('islandora:newspaperCModel', $object->models)) {
       // Do newspaper things
-    }
-    elseif (in_array('islandora:bookCModel', $object->models)) {
-      // Add PRESERVATION datastream to all pages.
-      module_load_include('inc', 'islandora_paged_content', 'includes/utilities');
-      $pages = islandora_paged_content_get_pages($object);
-      dd($pages);
-      foreach ($pages AS $page) {
-        $page_object = islandora_object_load($page['pid']);
-        islandora_westvault_add_preservation_datastream($page_object);
+      module_load_include('inc', 'islandora_newspaper', 'includes/utilities');
+      $issues = islandora_newspaper_get_issues($object);
+      dd($issues);
+      foreach ($issues AS $issue) {
+        $issue_object = islandora_object_load($issue['pid']);
+        islandora_westvault_add_preservation_datastream($issue_object);
+        islandora_westvault_preserve_pages($issue);
       }
+    }
+    elseif (in_array('islandora:bookCModel', $object->models) || in_array('islandora:newspaperIssueCModel', $object->models)) {
+      // Add PRESERVATION datastream to all pages.
+      islandora_westvault_preserve_pages($object);
     }
   }
   else {
     $object->purgeDatastream('PRESERVATION');
     drupal_set_message(t('Preservation data removed'));
+  }
+}
+
+function islandora_westvault_preserve_pages($parent) {
+  module_load_include('inc', 'islandora_paged_content', 'includes/utilities');
+  $parent_object = islandora_object_load($parent['pid']);
+  $pages = islandora_paged_content_get_pages($parent_object);
+  foreach ($pages AS $page) {
+    $page_object = islandora_object_load($page['pid']);
+    islandora_westvault_add_preservation_datastream($page_object);
   }
 }
 

--- a/islandora_westvault.module
+++ b/islandora_westvault.module
@@ -122,11 +122,21 @@ function islandora_westvault_islandora_object_ingested(AbstractObject $object) {
           $preserve_children = TRUE;
           break;
         }
+        elseif (in_array('islandora:newspaperCModel', $parent_test->models)) {
+          $preserve_children = TRUE;
+          break;
+        }
       }
     }
     if (isset($preserve_children)) {
       module_load_include('inc', 'islandora_westvault', 'includes/management_form');
       islandora_westvault_add_preservation_datastream($object);
+      // The preserve_pages function cannot take a whole object; it needs an array with the 'pid' key.
+      if (in_array('islandora:newspaperIssueCModel', $object->models) || in_array('islandora:bookCModel', $object->models)) {
+        $issue = array();
+        $issue['pid'] = $object->id;
+        islandora_westvault_preserve_pages($issue);
+      }
     }
   }
 }


### PR DESCRIPTION
I added some functions to detect whether the preserved object is a Newspaper, Book, or Newspaper Issue object, and add PRESERVATION datastreams to its children accordingly.

This functionality is redundant if Islandora Bagit gets paged content support, but I don't know what the status of that is at the moment.

Note that this PR will need to be updated anyway - need to add a check on ingest - if object is newspaperIssue or page, check parent and preserve if necessary.

@mjordan your thoughts?