### PR TITLE
Using islandora_bagit_complex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,14 @@ before_install:
   - git clone -b 7.x git://github.com/Islandora/islandora_bagit.git
   - git clone -b 7.x git://github.com/mjordan/islandora_westvault_extras.git
   - git clone -b 7.x git://github.com/Islandora/islandora_solr_search.git
+  - git clone -b 7.x git://github.com/mjordan/islandora_bagit_complex.git
   - export ISLANDORA_DIR=$HOME/islandora
   - $HOME/islandora/tests/scripts/travis_setup.sh
   - cd $HOME/drupal-*
   - ln -s $TRAVIS_BUILD_DIR sites/all/modules/islandora_westvault
   - ln -s $HOME/islandora_bagit sites/all/modules/islandora_bagit
   - ln -s $HOME/islandora_westvault_extras sites/all/modules/islandora_westvault_extras
+  - ln -s $HOME/islandora_bagit_complex sites/all/modules/islandora_bagit_complex
   - ln -s $HOME/islandora_solr_search sites/all/modules/islandora_solr_search
   - drush cc all
   - drush -u 1 en --yes islandora_bagit islandora_westvault_extras islandora_solr islandora_westvault

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The following Drupal modules are required:
  * [Islandora Collection Solution Pack](https://github.com/islandora/islandora_solution_pack_collection)
  * [Islandora Solr Search](https://github.com/islandora/islandora_solr_search)
  * [Islandora Bag-It](https://github.com/islandora/islandora_bagit)
+ * [Islandora Bag-It Complex](https://github.com/mjordan/islandora_bagit_complex)
  * [Islandora Westvault Extras](https://github.com/mjordan/islandora_westvault_extras)
 
 External tools:
@@ -48,6 +49,8 @@ In OwnCloud:
 Configuring Islandora Bag-it:
 
 * Change the Collection Batch Type settings to "Collection object only". Islandora Westvault works by preserving individual objects; collection bags with multiple objects in them may cause problems such as duplication in your LOCKSS account.
+* Under "Complex Objects", select Books and Newspaper Issues. (Do not select Newspapers or Compound Objects; Islandora Westvault handles their children individually.)
+* Check the "Add WestVault Tags" option.
 
 On your webserver:
 

--- a/includes/management_form.inc
+++ b/includes/management_form.inc
@@ -84,6 +84,15 @@ function islandora_westvault_form_submit($form, &$form_state) {
         }
       }
     }
+     elseif (in_array('islandora:newspaperCModel', $object->models)) {
+      // Add Preservation tag to issues
+      module_load_include('inc', 'islandora_newspaper', 'includes/utilities');
+      $issues = islandora_newspaper_get_issues($object);
+      foreach ($issues AS $issue) {
+        $issue_object = islandora_object_load($issue['pid']);
+        islandora_westvault_add_preservation_datastream($issue_object);
+      }
+    }
   }
   else {
     $object->purgeDatastream('PRESERVATION');

--- a/includes/management_form.inc
+++ b/includes/management_form.inc
@@ -135,7 +135,6 @@ function islandora_westvault_add_preservation_datastream($object, &$form_state =
         $content_string = $content_string . '<preservationMethod>' . $preservation_method . '</preservationMethod>';
       }
       $content_string = $content_string . '</preservation>';
-
       $ds->setContentFromString($content_string);
       $object->ingestDatastream($ds);
       drupal_set_message(t('Preservation data created'));

--- a/includes/management_form.inc
+++ b/includes/management_form.inc
@@ -84,13 +84,22 @@ function islandora_westvault_form_submit($form, &$form_state) {
         }
       }
     }
-     elseif (in_array('islandora:newspaperCModel', $object->models)) {
+    elseif (in_array('islandora:newspaperCModel', $object->models)) {
       // Add Preservation tag to issues
       module_load_include('inc', 'islandora_newspaper', 'includes/utilities');
       $issues = islandora_newspaper_get_issues($object);
       foreach ($issues AS $issue) {
         $issue_object = islandora_object_load($issue['pid']);
         islandora_westvault_add_preservation_datastream($issue_object);
+      }
+    }
+    // Deal with Compound objects too
+    elseif (in_array('islandora:compoundCModel', $object->models)) {
+      module_load_include('module', 'islandora_compound_object', 'islandora_compound_object');
+      $compound_parts = islandora_compound_object_get_parts($object->id);
+      foreach ($compound_parts AS $part) {
+        $part_object = islandora_object_load($part);
+        islandora_westvault_add_preservation_datastream($part_object);
       }
     }
   }

--- a/includes/management_form.inc
+++ b/includes/management_form.inc
@@ -95,7 +95,7 @@ function islandora_westvault_form_submit($form, &$form_state) {
     }
     // Deal with Compound objects too
     elseif (in_array('islandora:compoundCModel', $object->models)) {
-      module_load_include('module', 'islandora_compound_object', 'islandora_compound_object');
+      module_load_include('module', 'islandora_compound_object');
       $compound_parts = islandora_compound_object_get_parts($object->id);
       foreach ($compound_parts AS $part) {
         $part_object = islandora_object_load($part);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -5,6 +5,7 @@
  */
 function islandora_westvault_get_preservation_targets() {
   // Looking for the PRESERVATION datastream
+  module_load_include('module', 'islandora_compound_object');
   $query = "fedora_datastreams_ms:PRESERVATION";
   $qp = new islandoraSolrQueryProcessor();
   $qp->buildQuery($query);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -9,6 +9,18 @@ function islandora_westvault_get_preservation_targets() {
   $qp = new islandoraSolrQueryProcessor();
   $qp->buildQuery($query);
   $qp->solrParams['fl'] = "PID";
+  // Check islandora_compound_object settings and changes query filters to include compound children if necessary.
+  if (variable_get('islandora_compound_object_hide_child_objects_solr', TRUE)) {
+    $fq = variable_get('islandora_compound_object_solr_fq', '-RELS_EXT_isConstituentOf_uri_mt:[* TO *]');
+    if (!empty($fq)) {
+    // delete islandora_compound_object_solr_fq from the list of filters
+      $filters = $qp->solrParams['fq'];
+      if (($key = array_search($fq, $filters)) !== false) {
+        unset($filters[$key]);
+        $qp->solrParams['fq'] = $filters;
+      }
+    }
+  }
   $qp->solrLimit = 1000000;
   $qp->executeQuery(FALSE);
   try {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -16,7 +16,7 @@ function islandora_westvault_get_preservation_targets() {
     if (!empty($fq)) {
     // delete islandora_compound_object_solr_fq from the list of filters
       $filters = $qp->solrParams['fq'];
-      if (($key = array_search($fq, $filters)) !== false) {
+      if (($key = array_search($fq, $filters)) !== FALSE) {
         unset($filters[$key]);
         $qp->solrParams['fq'] = $filters;
       }

--- a/islandora_westvault.info
+++ b/islandora_westvault.info
@@ -5,5 +5,6 @@ package = Islandora Tools
 dependencies[] = islandora
 dependencies[] = islandora_bagit
 dependencies[] = islandora_westvault_extras
+dependencies[] = islandora_bagit_complex
 core = 7.x
 version = 7.x-dev

--- a/islandora_westvault.module
+++ b/islandora_westvault.module
@@ -112,9 +112,12 @@ function islandora_westvault_islandora_basic_collection_share_migrate(AbstractOb
 
 function islandora_westvault_islandora_compound_object_children_added_to_parent($object, $parent_pids) {
   module_load_include('module', 'islandora_compound_object');
-  $parent_test = islandora_object_load($parent_pids);
-  $ds = $parent_test["PRESERVATION"];
-  if (!empty($ds)) {
-    islandora_westvault_add_preservation_datastream($object);
+  foreach ($parent_pids AS $parent_pid) {
+    $parent_test = islandora_object_load($parent_pid);
+    $ds = $parent_test["PRESERVATION"];
+    if (!empty($ds)) {
+      module_load_include('inc', 'islandora_westvault', 'includes/management_form');
+      islandora_westvault_add_preservation_datastream($object);
+    }
   }
 }

--- a/islandora_westvault.module
+++ b/islandora_westvault.module
@@ -75,6 +75,10 @@ function islandora_westvault_islandora_object_ingested(AbstractObject $object) {
           $preserve_children = TRUE;
           break;
         }
+        elseif (in_array('islandora:compoundCModel', $parent_test->models)) {
+          $preserve_children = TRUE;
+          break;
+        }
       }
     }
     if (isset($preserve_children)) {

--- a/islandora_westvault.module
+++ b/islandora_westvault.module
@@ -114,15 +114,15 @@ function islandora_westvault_islandora_basic_collection_share_migrate(AbstractOb
  * Implements hook_islandora_compound_object_children_added_to_parent().
  */
 function islandora_westvault_islandora_compound_object_children_added_to_parent($object, $parent_pids) {
-$object = $object['0'];
-$compound_child = islandora_object_load($object->id);
-  module_load_include('module', 'islandora_compound_object');
-  foreach ($parent_pids AS $parent_pid) {
-    $parent_test = islandora_object_load($parent_pid);
-    $ds = $parent_test["PRESERVATION"];
-    if (!empty($ds)) {
-      module_load_include('inc', 'islandora_westvault', 'includes/management_form');
-      islandora_westvault_add_preservation_datastream($compound_child);
+  foreach ($object AS $new_child) {
+    module_load_include('module', 'islandora_compound_object');
+    foreach ($parent_pids AS $parent_pid) {
+      $parent_test = islandora_object_load($parent_pid);
+      $ds = $parent_test["PRESERVATION"];
+      if (!empty($ds)) {
+        module_load_include('inc', 'islandora_westvault', 'includes/management_form');
+        islandora_westvault_add_preservation_datastream($new_child);
+      }
     }
   }
 }

--- a/islandora_westvault.module
+++ b/islandora_westvault.module
@@ -110,14 +110,19 @@ function islandora_westvault_islandora_basic_collection_share_migrate(AbstractOb
   }
 }
 
+/*
+ * Implements hook_islandora_compound_object_children_added_to_parent().
+ */
 function islandora_westvault_islandora_compound_object_children_added_to_parent($object, $parent_pids) {
+$object = $object['0'];
+$compound_child = islandora_object_load($object->id);
   module_load_include('module', 'islandora_compound_object');
   foreach ($parent_pids AS $parent_pid) {
     $parent_test = islandora_object_load($parent_pid);
     $ds = $parent_test["PRESERVATION"];
     if (!empty($ds)) {
       module_load_include('inc', 'islandora_westvault', 'includes/management_form');
-      islandora_westvault_add_preservation_datastream($object);
+      islandora_westvault_add_preservation_datastream($compound_child);
     }
   }
 }

--- a/islandora_westvault.module
+++ b/islandora_westvault.module
@@ -108,5 +108,13 @@ function islandora_westvault_islandora_basic_collection_share_migrate(AbstractOb
       islandora_westvault_add_preservation_datastream($object);
     }
   }
+}
 
+function islandora_westvault_islandora_compound_object_children_added_to_parent($object, $parent_pids) {
+  module_load_include('module', 'islandora_compound_object');
+  $parent_test = islandora_object_load($parent_pids);
+  $ds = $parent_test["PRESERVATION"];
+  if (!empty($ds)) {
+    islandora_westvault_add_preservation_datastream($object);
+  }
 }

--- a/islandora_westvault.module
+++ b/islandora_westvault.module
@@ -71,6 +71,10 @@ function islandora_westvault_islandora_object_ingested(AbstractObject $object) {
           $preserve_children = TRUE;
           break;
         }
+        elseif (in_array('islandora:newspaperCModel', $parent_test->models)) {
+          $preserve_children = TRUE;
+          break;
+        }
       }
     }
     if (isset($preserve_children)) {


### PR DESCRIPTION
This approach to complex objects makes use of islandora_bagit_complex to grab and bag pages.

Complications:

- Newspaper Issues may or may not be automatically preserved when added to a preserved Newspaper - this needs to be tested
- Same with Compound objects - they probably aren't but should be
- Requires that the user has particular Bagit settings (bag only the newspaper and not the children) which don't exist yet
- Do we use islandora_bagit_complex to deal with compound children, or skip its approach and just use our own?