### PR TITLE
Enforce settings in islandora_bagit

### DIFF
--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -62,7 +62,9 @@ function drush_islandora_westvault_run_islandora_westvault_sync_validate() {
   $user = variable_get('islandora_westvault_credentials_user', '');
   $password = variable_get('islandora_westvault_credentials_password', '');
   if (!isset($user) || !isset($password)) {
-    return drush_set_error('WESTVAULT_CREDENTIALS_NOT_SET', dt('Please set OwnCloud credentials in module configuration.'));
+    $error_message = t('Please set OwnCloud credentials in module configuration.');
+    watchdog("islandora_westvault", '%error_message', array('%error_message' => $error_message), WATCHDOG_ERROR);
+    return drush_set_error('WESTVAULT_CREDENTIALS_NOT_SET', $error_message);
   }
 }
 
@@ -83,13 +85,18 @@ function drush_islandora_westvault_run_islandora_westvault_bagit() {
   $complex_cmodels = variable_get('islandora_bagit_complex_cmodels', array(''));
   if ($plugins['plugin_object_ds_basic'] == '0') {
     $error_message = t('Operation aborted. Select the plugin "plugin_object_ds_basic" in your Islandora Bagit configuration.');
+    watchdog("islandora_westvault", '%error_message', array('%error_message' => $error_message), WATCHDOG_ERROR);
     return drush_set_error('DS_BASIC_PLUGIN_MISSING', $error_message);
   }
   if ($collection_setting !== 'no_children') {
-    return drush_set_error('BAGIT_COLLECTION_CONFIG', dt('Operation aborted. In Islandora Bagit Configuration, select "Collecion object only" under Collection Batch Type.'));
+    $error_message = t('Operation aborted. In Islandora Bagit Configuration, select "Collecion object only" under Collection Batch Type.');
+    watchdog("islandora_westvault", '%error_message', array('%error_message' => $error_message), WATCHDOG_ERROR);
+    return drush_set_error('BAGIT_COLLECTION_CONFIG', $error_message);
   }
   if ($complex_cmodels['islandora:bookCModel'] == '0' || $complex_cmodels['islandora:islandora:newspaperIssueCModel'] == '0' || $complex_cmodels['islandora:compoundCModel'] != '0' || $complex_cmodels['islandora:newspaperCModel'] != '0') {
-    return drush_set_error('BAGIT_COMPLEX_CONFIG', dt('Operation aborted. In Islandora Bagit Configuration, under Complex Objects select only Books and Newspaper Issues.'));
+    $error_message = t('Operation aborted. In Islandora Bagit Configuration, under Complex Objects select only Books and Newspaper Issues.');
+    watchdog("islandora_westvault", '%error_message', array('%error_message' => $error_message), WATCHDOG_ERROR);
+    return drush_set_error('BAGIT_COMPLEX_CONFIG', $error_message);
   }
   module_load_include('inc', 'islandora_westvault', 'includes/utilities');
   $timestamp = time();

--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -82,7 +82,8 @@ function drush_islandora_westvault_run_islandora_westvault_bagit() {
   $collection_setting = variable_get('islandora_bagit_multiple_bag_type', 'object');
   $complex_cmodels = variable_get('islandora_bagit_complex_cmodels', array(''));
   if ($plugins['plugin_object_ds_basic'] == '0') {
-    return drush_set_error('DS_BASIC_PLUGIN_MISSING', dt('Operation aborted. Select the plugin "plugin_object_ds_basic" in your Islandora Bagit configuration.'));
+    $error_message = t('Operation aborted. Select the plugin "plugin_object_ds_basic" in your Islandora Bagit configuration.');
+    return drush_set_error('DS_BASIC_PLUGIN_MISSING', $error_message);
   }
   if ($collection_setting !== 'no_children') {
     return drush_set_error('BAGIT_COLLECTION_CONFIG', dt('Operation aborted. In Islandora Bagit Configuration, select "Collecion object only" under Collection Batch Type.'));

--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -78,9 +78,17 @@ function drush_islandora_westvault_run_islandora_westvault_sync() {
 function drush_islandora_westvault_run_islandora_westvault_bagit() {
   // Goal: Detect objects with the preservation flag and preserve them. Skip objects already preserved.
   module_load_include('module', 'islandora_bagit');
-  $plugins = variable_get('islandora_bagit_object_plugins', array(''), true);
+  $plugins = variable_get('islandora_bagit_object_plugins', array(''));
+  $collection_setting = variable_get('islandora_bagit_multiple_bag_type', 'object');
+  $complex_cmodels = variable_get('islandora_bagit_complex_cmodels', array(''));
   if ($plugins['plugin_object_ds_basic'] == '0') {
-    return drush_set_error('DS_BASIC_PLUGIN_MISSING', dt('Please select the plugin "plugin_object_ds_basic" in your Islandora Bagit configuration.'));
+    return drush_set_error('DS_BASIC_PLUGIN_MISSING', dt('Operation aborted. Select the plugin "plugin_object_ds_basic" in your Islandora Bagit configuration.'));
+  }
+  if ($collection_setting !== 'no_children') {
+    return drush_set_error('BAGIT_COLLECTION_CONFIG', dt('Operation aborted. In Islandora Bagit Configuration, select "Collecion object only" under Collection Batch Type.'));
+  }
+  if ($complex_cmodels['islandora:bookCModel'] == '0' || $complex_cmodels['islandora:islandora:newspaperIssueCModel'] == '0' || $complex_cmodels['islandora:compoundCModel'] != '0' || $complex_cmodels['islandora:newspaperCModel'] != '0') {
+    return drush_set_error('BAGIT_COMPLEX_CONFIG', dt('Operation aborted. In Islandora Bagit Configuration, under Complex Objects select only Books and Newspaper Issues.'));
   }
   module_load_include('inc', 'islandora_westvault', 'includes/utilities');
   $timestamp = time();


### PR DESCRIPTION
Enforces the required configurations from islandora_bagit before the westvault-bagit drush command will complete.

To test:

- Set up some bad configurations in Islandora Bagit (set Collection Batch to whole collection, un-check the ds plugin option, and select Compound and Newspaper options in the Complex section).
- Run `drush -u 1 westvault-bagit` and watch for errors
- Fix the errors one at a time until the operation runs successfully