### PR TITLE
Validate bags before updating and syncing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,19 @@ matrix:
     - php: 5.3.3
       dist: precise
       env: FEDORA_VERSION="3.8.1"
+  allow_failures:
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.5"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.6.2"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.7.0"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.8.1"
 php:
   - 5.4
   - 5.5

--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -52,15 +52,6 @@ function islandora_westvault_drush_command() {
     'aliases' => array('westvault-bagit'),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
-  $items['run-islandora-westvault-validate-bags'] = array(
-    'description' => dt('Validates Bags created by this module.'),
-    'examples' => array(
-      'Standard example' => 'drush -u 1 run-islandora-westvault-validate-bags',
-      'Alias example' => 'drush -u 1 westvault-validate-bags',
-    ),
-    'aliases' => array('westvault-validate-bags'),
-    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
-  );
   return $items;
 }
 

--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -127,7 +127,9 @@ function drush_islandora_westvault_run_islandora_westvault_bagit() {
 
   // Pass object list to Bag-It
   module_load_include('module', 'islandora_bagit');
-  $bagit_directory = variable_get('islandora_bagit_tmp_dir', file_directory_temp());
+  $bagit_default_dir = variable_get('file_public_path', conf_path() . '/files');
+  $bagit_directory = variable_get('islandora_bagit_bag_output_dir', $bagit_default_dir);
+//$bagit_directory = variable_get('islandora_westvault_owncloud_path', 'tmp/owncloud/');
   $bag_filename_prefix = variable_get('islandora_bagit_bag_name', 'Bag-');
 
   foreach ($filtered_list AS $object) {

--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -155,8 +155,15 @@ function drush_islandora_westvault_run_islandora_westvault_bagit() {
       $ds_content_updated = $dom->saveXML($dom->documentElement);
       $ds->setContentFromString($ds_content_updated);
     }
-  // ELSE: We should delte the bag so it doesn't get preserved, and log it.
-
+  // If the bag is not valid, delete it so it doesn't get preserved, and log it.
+    else {
+      $filename_pid = str_replace(array(':', '-'), '_', $object);
+      $bag_file_name = $bag_filename_prefix . $filename_pid . ".tgz";
+      $bag_path = $bagit_directory . $bag_file_name;
+      unlink($bag_path);
+      drush_log(dt("Bag !bag was is missing files and will be removed. Check directory permissions and try again.",
+        array('!bag' => $bag_path), 'warning'));
+    }
   }
 }
 
@@ -193,6 +200,9 @@ function islandora_westvault_validate_bag($pid, $bagit_directory, $bag_filename_
   // Prevents an incorrect 'false' result in the array_search below.
     $bag_contents['zero'] = $bag_contents[0];
     unset($bag_contents[0]);
+
+// FOR TESTING ONLY
+unset($bag_contents['zero']);
 
   // Compare $datastreams to $bag_contents.
     foreach ($datastreams AS $datastream) {

--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -134,13 +134,13 @@ function drush_islandora_westvault_run_islandora_westvault_bagit() {
   foreach ($filtered_list AS $object) {
     $object_get = islandora_object_load($object);
     // Bag-it does not work on collections.
-      islandora_bagit_create_bag($object_get);
+    islandora_bagit_create_bag($object_get);
 
-      // Now validate bag before updating PRESERVATION
+    // Now validate bag before updating PRESERVATION
 
-      $is_valid = islandora_westvault_validate_bag($object, $bagit_directory, $bag_filename_prefix);
+    $is_valid = islandora_westvault_validate_bag($object, $bagit_directory, $bag_filename_prefix);
 
-
+    if($is_valid == TRUE) {
       // Update the PRESERVATION datastream to timestamp successful preservation
       $ds = $object_get["PRESERVATION"];
       $ds_content = $ds->content;
@@ -148,13 +148,15 @@ function drush_islandora_westvault_run_islandora_westvault_bagit() {
       $dom->preserveWhiteSpace = FALSE;
       $dom->formatOutput = TRUE;
       $dom->loadXML($ds_content);
-    
       $fragment = "<confirmPreserved>" . $timestamp . "</confirmPreserved>";
       $frag = $dom->createDocumentFragment();
       $frag->appendXML($fragment);
       $dom->documentElement->appendChild($frag);
       $ds_content_updated = $dom->saveXML($dom->documentElement);
       $ds->setContentFromString($ds_content_updated);
+    }
+  // ELSE: We should delte the bag so it doesn't get preserved, and log it.
+
   }
 }
 
@@ -163,7 +165,6 @@ function islandora_westvault_validate_bag($pid, $bagit_directory, $bag_filename_
 
   $bag_file_name = $bag_filename_prefix . $filename_pid . ".tgz";
   $bag_path = $bagit_directory . $bag_file_name;
-dd($bag_path);
   $bagit_library_dir = variable_get('islandora_bagit_library_dir', 'BagItPHP');
   if ($bagit_library_path = libraries_get_path($bagit_library_dir)) {
     require_once $bagit_library_path . '/lib/bagit.php';
@@ -178,18 +179,40 @@ dd($bag_path);
   // Get the object's Solr document and use the fedora_datastreams_ms field to compare.
     $datastreams = islandora_westvault_get_datastreams($pid);
 
-    dd($datastreams);
-    dd($bag_files);
+    $bag_contents = array();
 
-    $is_valid = TRUE;
+    foreach ($bag_files AS $bag_file) {
+      $trimmed_filename = explode("/", $bag_file);
+      $bag_contents[] = explode(".", end($trimmed_filename))[0];
+    }
+
+  // Remove the AUDIT datastream before comparing lists.
+    $audit_key = array_search("AUDIT", $datastreams);
+    unset($datastreams[$audit_key]);
+
+  // Prevents an incorrect 'false' result in the array_search below.
+    $bag_contents['zero'] = $bag_contents[0];
+    unset($bag_contents[0]);
+
+  // Compare $datastreams to $bag_contents.
+    foreach ($datastreams AS $datastream) {
+      $datastream_locator = array_search($datastream, $bag_contents, true);
+
+      if ($datastream_locator == FALSE) {
+        drush_log(dt("Bag at !path missing the !datastream datastream.", array('!path' => $bag_path, '!datastream' => $datastream), 'warning'));
+        $is_valid = FALSE;
+      }
+    }
+    if (!isset($is_valid)) {
+      $is_valid = TRUE;
+    }
   }
   else {
-    drush_log(dt("Bag at !path does not validate.", array('!path' => $path), 'warning'));
-    dd('invalid bag');
+    drush_log(dt("Bag at !path does not validate.", array('!path' => $bag_path), 'warning'));
     $is_valid = FALSE;
   }
 
-
+  return($is_valid);
 }
 
 function islandora_westvault_get_datastreams($pid) {

--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -131,7 +131,7 @@ function drush_islandora_westvault_run_islandora_westvault_bagit() {
 
     $is_valid = islandora_westvault_validate_bag($object, $bagit_directory, $bag_filename_prefix);
 
-    if($is_valid == TRUE) {
+    if ($is_valid == TRUE) {
       // Update the PRESERVATION datastream to timestamp successful preservation
       $ds = $object_get["PRESERVATION"];
       $ds_content = $ds->content;
@@ -194,7 +194,7 @@ function islandora_westvault_validate_bag($pid, $bagit_directory, $bag_filename_
 
   // Compare $datastreams to $bag_contents.
     foreach ($datastreams AS $datastream) {
-      $datastream_locator = array_search($datastream, $bag_contents, true);
+      $datastream_locator = array_search($datastream, $bag_contents, TRUE);
 
       if ($datastream_locator == FALSE) {
         drush_log(dt("Bag at !path missing the !datastream datastream.", array('!path' => $bag_path, '!datastream' => $datastream), 'warning'));
@@ -210,7 +210,7 @@ function islandora_westvault_validate_bag($pid, $bagit_directory, $bag_filename_
     $is_valid = FALSE;
   }
 
-  return($is_valid);
+  return ($is_valid);
 }
 
 function islandora_westvault_get_datastreams($pid) {
@@ -232,5 +232,5 @@ function islandora_westvault_get_datastreams($pid) {
       $datastreams_array = ($qp->islandoraSolrResult['response']['objects']['0']['solr_doc'][$query_field]);
     }
   }
-  return($datastreams_array);
+  return ($datastreams_array);
 }

--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -152,8 +152,10 @@ function drush_islandora_westvault_run_islandora_westvault_bagit() {
       $bag_file_name = $bag_filename_prefix . $filename_pid . ".tgz";
       $bag_path = $bagit_directory . $bag_file_name;
       unlink($bag_path);
-      drush_log(dt("Bag !bag was is missing files and will be removed. Check directory permissions and try again.",
-        array('!bag' => $bag_path), 'warning'));
+
+      $error_message = dt("Bag !bag was missing files and will be removed. Check directory permissions and try again.",
+        array('!bag' => $bag_path));
+      watchdog("islandora_westvault", '%error_message', array('%error_message' => $error_message), WATCHDOG_ERROR);
     }
   }
 }

--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -124,12 +124,22 @@ function drush_islandora_westvault_run_islandora_westvault_bagit() {
   }
   global $base_url;
   $sitename = parse_url($base_url);
-  // Use bag-it
+
+  // Pass object list to Bag-It
   module_load_include('module', 'islandora_bagit');
+  $bagit_directory = variable_get('islandora_bagit_tmp_dir', file_directory_temp());
+  $bag_filename_prefix = variable_get('islandora_bagit_bag_name', 'Bag-');
+
   foreach ($filtered_list AS $object) {
     $object_get = islandora_object_load($object);
     // Bag-it does not work on collections.
       islandora_bagit_create_bag($object_get);
+
+      // Now validate bag before updating PRESERVATION
+
+      $is_valid = islandora_westvault_validate_bag($object, $bagit_directory, $bag_filename_prefix);
+
+
       // Update the PRESERVATION datastream to timestamp successful preservation
       $ds = $object_get["PRESERVATION"];
       $ds_content = $ds->content;
@@ -147,25 +157,58 @@ function drush_islandora_westvault_run_islandora_westvault_bagit() {
   }
 }
 
-function drush_islandora_westvault_run_islandora_westvault_validate_bags() {
-  // Validate a bag at $path.
-  $path = '/tmp/Bag-islandora_7.tgz';
+function islandora_westvault_validate_bag($pid, $bagit_directory, $bag_filename_prefix) {
+  $filename_pid = str_replace(array(':', '-'), '_', $pid);
 
-  // Load the BagItPHP library.
+  $bag_file_name = $bag_filename_prefix . $filename_pid;
+  $bag_path = $bagit_directory . DIRECTORY_SEPARATOR . $bag_file_name;
+dd($bag_path);
   $bagit_library_dir = variable_get('islandora_bagit_library_dir', 'BagItPHP');
   if ($bagit_library_path = libraries_get_path($bagit_library_dir)) {
     require_once $bagit_library_path . '/lib/bagit.php';
   }
-
-  $bag = new BagIt($path);
-
+  $bag = new BagIt($bag_path);
+  $bag_files = array();
   if ($bag->isValid()) {
-    drush_log(dt("Bag at !path validates.", array('!path' => $path), 'info'));
+    drush_log(dt("Bag at !path validates.", array('!path' => $bag_path), 'info'));
     foreach ($bag->getBagContents() as $filename) {
-      print $filename . "\n";
+      $bag_files[] = $filename;
     }
+  // Get the object's Solr document and use the fedora_datastreams_ms field to compare.
+    $datastreams = islandora_westvault_get_datastreams($pid);
+
+    dd($datastreams);
+    dd($bag_files);
+
+    $is_valid = TRUE;
   }
   else {
     drush_log(dt("Bag at !path does not validate.", array('!path' => $path), 'warning'));
+    dd('invalid bag');
+    $is_valid = FALSE;
   }
+
+
+}
+
+function islandora_westvault_get_datastreams($pid) {
+  $qp = new IslandoraSolrQueryProcessor();
+  $qp->buildQuery(format_string('@field:"@pid"', array(
+    '@field' => 'PID',
+    '@pid' => "{$pid}")
+  ));
+  $query_field = 'fedora_datastreams_ms';
+  $qp->solrParams['fl'] = implode(', ', array(
+    'PID',
+    $query_field,
+  ));
+  $qp->solrStart = 0;
+  $qp->solrLimit = 100000;
+  $qp->executeQuery(FALSE);
+  if ($qp->islandoraSolrResult['response']['numFound'] > 0) {
+    if (array_key_exists($query_field, $qp->islandoraSolrResult['response']['objects']['0']['solr_doc'])) {
+      $datastreams_array = ($qp->islandoraSolrResult['response']['objects']['0']['solr_doc'][$query_field]);
+    }
+  }
+  return($datastreams_array);
 }

--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -201,9 +201,6 @@ function islandora_westvault_validate_bag($pid, $bagit_directory, $bag_filename_
     $bag_contents['zero'] = $bag_contents[0];
     unset($bag_contents[0]);
 
-// FOR TESTING ONLY
-unset($bag_contents['zero']);
-
   // Compare $datastreams to $bag_contents.
     foreach ($datastreams AS $datastream) {
       $datastream_locator = array_search($datastream, $bag_contents, true);

--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -128,8 +128,7 @@ function drush_islandora_westvault_run_islandora_westvault_bagit() {
   // Pass object list to Bag-It
   module_load_include('module', 'islandora_bagit');
   $bagit_default_dir = variable_get('file_public_path', conf_path() . '/files');
-  $bagit_directory = variable_get('islandora_bagit_bag_output_dir', $bagit_default_dir);
-//$bagit_directory = variable_get('islandora_westvault_owncloud_path', 'tmp/owncloud/');
+  $bagit_directory = variable_get('islandora_westvault_owncloud_path', '/tmp/owncloud/');
   $bag_filename_prefix = variable_get('islandora_bagit_bag_name', 'Bag-');
 
   foreach ($filtered_list AS $object) {
@@ -162,8 +161,8 @@ function drush_islandora_westvault_run_islandora_westvault_bagit() {
 function islandora_westvault_validate_bag($pid, $bagit_directory, $bag_filename_prefix) {
   $filename_pid = str_replace(array(':', '-'), '_', $pid);
 
-  $bag_file_name = $bag_filename_prefix . $filename_pid;
-  $bag_path = $bagit_directory . DIRECTORY_SEPARATOR . $bag_file_name;
+  $bag_file_name = $bag_filename_prefix . $filename_pid . ".tgz";
+  $bag_path = $bagit_directory . $bag_file_name;
 dd($bag_path);
   $bagit_library_dir = variable_get('islandora_bagit_library_dir', 'BagItPHP');
   if ($bagit_library_path = libraries_get_path($bagit_library_dir)) {

--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -52,6 +52,15 @@ function islandora_westvault_drush_command() {
     'aliases' => array('westvault-bagit'),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
+  $items['run-islandora-westvault-validate-bags'] = array(
+    'description' => dt('Validates Bags created by this module.'),
+    'examples' => array(
+      'Standard example' => 'drush -u 1 run-islandora-westvault-validate-bags',
+      'Alias example' => 'drush -u 1 westvault-validate-bags',
+    ),
+    'aliases' => array('westvault-validate-bags'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
+  );
   return $items;
 }
 
@@ -135,5 +144,28 @@ function drush_islandora_westvault_run_islandora_westvault_bagit() {
       $dom->documentElement->appendChild($frag);
       $ds_content_updated = $dom->saveXML($dom->documentElement);
       $ds->setContentFromString($ds_content_updated);
+  }
+}
+
+function drush_islandora_westvault_run_islandora_westvault_validate_bags() {
+  // Validate a bag at $path.
+  $path = '/tmp/Bag-islandora_7.tgz';
+
+  // Load the BagItPHP library.
+  $bagit_library_dir = variable_get('islandora_bagit_library_dir', 'BagItPHP');
+  if ($bagit_library_path = libraries_get_path($bagit_library_dir)) {
+    require_once $bagit_library_path . '/lib/bagit.php';
+  }
+
+  $bag = new BagIt($path);
+
+  if ($bag->isValid()) {
+    drush_log(dt("Bag at !path validates.", array('!path' => $path), 'info'));
+    foreach ($bag->getBagContents() as $filename) {
+      print $filename . "\n";
+    }
+  }
+  else {
+    drush_log(dt("Bag at !path does not validate.", array('!path' => $path), 'warning'));
   }
 }


### PR DESCRIPTION
Addresses #22 

Adds validation functions to check bag contents against the object's datastreams.

If any datastream is not represented by a file in the Bag, the error is logged and the Bag is deleted. The object's PRESERVATION datastream is not updated, so it will still be ready to be preserved next time.

To test:

- Set an object to be preserved as normal
- Run `drush -u 1 westvault-bagit --debug`
- Check your Owncloud directry; bag should be there and all should be well
- Ensure that a bad Bag is created: Edit `islandora_westvault.drush.inc` and add the following at line 196:
```
// FOR TESTING ONLY	
unset($bag_contents['zero']);
```
- Un-preserve your object, then preserve again
- Run the drush command `drush -u 1 westvault-bagit --debug`
- Observe the logged error
- Check your Owncloud directory -- the Bag should not be there