### PR TITLE
Add maximum filesize check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: true
 language: php
+dist: trusty
 matrix:
   include:
    #5.3.3 Ubuntu Precise exceptions

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ php:
   - 7.0
   - 7.1
 
+services:
+  - mysql
+
 branches:
   only:
     - /^7.x/

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -35,6 +35,12 @@ function islandora_westvault_admin(array $form, array &$form_state) {
     '#description' => t('Path to your temporary file where PIDs of objects to be preserved are stored. Include trailing slash.'),
     '#default_value' => variable_get('islandora_westvault_pid_file_location', '/tmp/'),
   );
+  $form['islandora_westvault_max_filesize'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Maximum filesize in Westvault (in GB)'),
+    '#description' => t('The maximum filesize allowed by Westvault, in GB. This is currently 2 GB. Enter an integer only, no units.'),
+    '#default_value' => variable_get('islandora_westvault_max_filesize', '2'),
+  );
   $form['islandora_westvault_credentials_user'] = array(
     '#type' => 'textfield',
     '#title' => t('OwnCloud user ID'),

--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -206,7 +206,6 @@ function islandora_westvault_validate_bag($pid, $bagit_directory, $bag_filename_
 
     $filesize = round(filesize($bag_path) / 1024 / 1024 / 1024, 1);
     $max_filesize = variable_get(islandora_westvault_max_filesize, '2');
-dd($max_filesize);
     if ($filesize > $max_filesize) {
       $is_valid = FALSE;
       drush_log(dt("Bag at !path is over !maxfile GB and cannot be sent to Westvault.", array('!path' => $bag_path, '!maxfile' => $max_filesize), 'warning'));

--- a/islandora_westvault.drush.inc
+++ b/islandora_westvault.drush.inc
@@ -153,7 +153,7 @@ function drush_islandora_westvault_run_islandora_westvault_bagit() {
       $bag_path = $bagit_directory . $bag_file_name;
       unlink($bag_path);
 
-      $error_message = dt("Bag !bag was missing files and will be removed. Check directory permissions and try again.",
+      $error_message = dt("Bag !bag has errors and will be removed. Check directory permissions and try again.",
         array('!bag' => $bag_path));
       watchdog("islandora_westvault", '%error_message', array('%error_message' => $error_message), WATCHDOG_ERROR);
     }
@@ -202,6 +202,14 @@ function islandora_westvault_validate_bag($pid, $bagit_directory, $bag_filename_
         drush_log(dt("Bag at !path missing the !datastream datastream.", array('!path' => $bag_path, '!datastream' => $datastream), 'warning'));
         $is_valid = FALSE;
       }
+    }
+
+    $filesize = round(filesize($bag_path) / 1024 / 1024 / 1024, 1);
+    $max_filesize = variable_get(islandora_westvault_max_filesize, '2');
+dd($max_filesize);
+    if ($filesize > $max_filesize) {
+      $is_valid = FALSE;
+      drush_log(dt("Bag at !path is over !maxfile GB and cannot be sent to Westvault.", array('!path' => $bag_path, '!maxfile' => $max_filesize), 'warning'));
     }
     if (!isset($is_valid)) {
       $is_valid = TRUE;


### PR DESCRIPTION
Deals with #45 

New menu option: Maximum filesize in Westvault (defaults to 2 GB)

New check: compares Bag size to size limit, declared invalid if over the limit.

Thoughts, @mjordan?